### PR TITLE
Minor enhancements and bugfixes

### DIFF
--- a/src/bot/__main__.py
+++ b/src/bot/__main__.py
@@ -81,7 +81,8 @@ async def main():
             YEAR: [CallbackQueryHandler(application_dialog_year, pattern="application_dialog_year_*")],
             VALIDATE: [CallbackQueryHandler(application_dialog_validate, pattern="proceed_subscribe|cancel_subscribe")],
         },
-        fallbacks=[CommandHandler("subscribe", subscribe_command, has_args=False)],
+        fallbacks=[CommandHandler("subscribe", subscribe_command, has_args=False),
+                   CommandHandler("start", start_command, has_args=False)],
     )
     bot.add_handler(conv_handler)
     bot.add_handler(MessageHandler(filters.COMMAND, unknown))


### PR DESCRIPTION
- /start command can be issued more than once
- application number parsing has been improved by checking against a regex, so now oam-5678-9, 5678-9, oAM-5678, 5678 are all valid user inputs
- suffix not being defaulted to 0 but taken from user input if supplied.