### PR TITLE
Introduce language choice during /start

### DIFF
--- a/db-init-scripts/init.sql
+++ b/db-init-scripts/init.sql
@@ -11,5 +11,5 @@ CREATE TABLE IF NOT EXISTS Applications (
     current_status VARCHAR(255),
     last_updated TIMESTAMP,
     is_resolved BOOLEAN NOT NULL DEFAULT FALSE,
-    language VARCHAR(255) NOT NULL DEFAULT 'EN',
+    language VARCHAR(255) NOT NULL DEFAULT 'EN'
 );

--- a/src/bot/__main__.py
+++ b/src/bot/__main__.py
@@ -13,7 +13,6 @@ from bot.handlers import (
     application_dialog_year,
     application_dialog_type,
     application_dialog_validate,
-    LANG,
     START,
     NUMBER,
     TYPE,
@@ -78,8 +77,8 @@ async def main():
             CommandHandler("start", start_command, has_args=False),
         ],
         states={
-            LANG: [CallbackQueryHandler(set_language_startup, pattern="set_lang_*")],
-            START: [CallbackQueryHandler(subscribe_button)],
+            START: [CallbackQueryHandler(subscribe_button, pattern="subscribe"),
+                    CallbackQueryHandler(set_language_startup, pattern="set_lang_*")],
             NUMBER: [MessageHandler(filters.TEXT, application_dialog_number)],
             TYPE: [CallbackQueryHandler(application_dialog_type, pattern="application_dialog_type_*")],
             YEAR: [CallbackQueryHandler(application_dialog_year, pattern="application_dialog_year_*")],


### PR DESCRIPTION
Alongside subscribe button language select buttons are present. Once clicked a new subscribe button will be shown. Also fixed init.sql (redundant comma that broke initialization).

Issue: #14