### PR TITLE
Stricten check for /subscribe with arguments

### DIFF
--- a/src/bot/handlers.py
+++ b/src/bot/handlers.py
@@ -218,6 +218,10 @@ def _parse_application_number_full(num_str: str):
     matched = re.match(num_regex, num_str)
     if not matched:
         return
+    # check that type and number are among allowed
+    if matched[4] not in ALLOWED_TYPES or int(matched[5]) not in ALLOWED_YEARS:
+        logger.info("Application type %s or year %s are unsupported", matched[4], matched[5])
+        return
     return matched[2], (matched[3] or "0").lstrip("-"), matched[4], matched[5]
 
 

--- a/src/tests/test_bot.py
+++ b/src/tests/test_bot.py
@@ -26,7 +26,8 @@ from bot.handlers import (
     set_language_startup,
 )
 
-
+@patch('bot.handlers.ALLOWED_YEARS', [2020, 2021, 2022, 2023, 2042])
+@patch('bot.handlers.ALLOWED_TYPES', ['MK', 'DO', 'TP'])
 @pytest.mark.parametrize(
     "num_str, app_num, app_suffix, app_type, app_year",
     [
@@ -34,6 +35,8 @@ from bot.handlers import (
         ("4242-5/DO-2020", "4242", "5", "DO", "2020"),
         ("oAM-12345-9/MK-2023", "12345", "9", "MK", "2023"),
         ("BAD-NUMBER/MK-2023", None, None, None, None),
+        ("oam-4242-6/MK-1999", None, None, None, None),
+        ("oam-4242-6/NT-2021", None, None, None, None),
     ],
 )
 def test__parse_application_number_full(num_str, app_num, app_suffix, app_type, app_year):


### PR DESCRIPTION
Previously the subscribe command arguments were checked only against regex, so it was possible to input type and year which were actually not supported.
Tests added as well.

Closes: #23