### PR TITLE
Restrict suffix to 2 digits only

### DIFF
--- a/src/bot/handlers.py
+++ b/src/bot/handlers.py
@@ -227,7 +227,7 @@ def _parse_application_number_full(num_str: str):
     This function returns a tuple (number, suffix, type, year) in case of success or None otherwise.
     """
     num_str = num_str.replace(" ", "").upper()
-    num_regex = r"^(OAM-){0,1}0{0,5}([1-9]{1}[0-9]{0,4})(-[0-9]+){0,1}/([A-Z]{2})-([0-9]{4})$"
+    num_regex = r"^(OAM-){0,1}0{0,5}([1-9]{1}[0-9]{0,4})(-[0-9]{1,2}){0,1}/([A-Z]{2})-([0-9]{4})$"
     matched = re.match(num_regex, num_str)
     if not matched:
         return
@@ -246,7 +246,7 @@ def _parse_application_number(num_str: str):
     This function returns a tuple (number, suffix) in case of success or None otherwise.
     """
     num_str = num_str.replace(" ", "").upper()
-    num_regex = r"^(OAM-){0,1}0{0,5}([1-9]{1}[0-9]{0,4})(-[0-9]+){0,1}$"
+    num_regex = r"^(OAM-){0,1}0{0,5}([1-9]{1}[0-9]{0,4})(-[0-9]{1,2}){0,1}$"
     matched = re.match(num_regex, num_str)
     if not matched:
         return

--- a/src/tests/test_bot.py
+++ b/src/tests/test_bot.py
@@ -33,12 +33,16 @@ from bot.handlers import (
     "num_str, app_num, app_suffix, app_type, app_year",
     [
         ("OAM-4242/TP-2042", "4242", "0", "TP", "2042"),
+        ("12345/TP-2023", "12345", "0", "TP", "2023"),
         ("4242-5/DO-2020", "4242", "5", "DO", "2020"),
         ("oAM-12345-9/MK-2023", "12345", "9", "MK", "2023"),
         ("BAD-NUMBER/MK-2023", None, None, None, None),
         ("oam-4242-6/MK-1999", None, None, None, None),
         ("oam-4242-6/NT-2021", None, None, None, None),
         ("OAM-00004-1/MK-2020", "4", "1", "MK", "2020"),
+        ("OAM-00004-99/MK-2020", "4", "99", "MK", "2020"),
+        # suffix too long
+        ("oAM-12345-911/MK-2023", None, None, None, None),
     ],
 )
 def test__parse_application_number_full(num_str, app_num, app_suffix, app_type, app_year):
@@ -53,10 +57,14 @@ def test__parse_application_number_full(num_str, app_num, app_suffix, app_type, 
     "num_str, app_num, app_suffix",
     [
         ("OAM-4242/TP-2042", "4242", "0"),
+        ("12345/TP-2023", "12345", "0"),
         ("4242-5/DO-2020", "4242", "5"),
         ("oAM-12345-9/MK-2023", "12345", "9"),
         ("BAD-NUMBER/MK-2023", None, None),
         ("OAM-00004-1", "4", "1"),
+        ("OAM-00004-99", "4", "99"),
+        # suffix too long
+        ("OAM-00004-108", None, None),
     ],
 )
 def test__parse_application_number(num_str, app_num, app_suffix):


### PR DESCRIPTION
Previously suffix length wasn't restricted which allowed for OAM-12345-2023 application number.
Some more tests for full regex and number-part-onl regex were added as well.

Closes: #40